### PR TITLE
fix: Corrige a query do webhook e padroniza o cliente Supabase

### DIFF
--- a/src/pages/DiagnosticoSistema.tsx
+++ b/src/pages/DiagnosticoSistema.tsx
@@ -9,9 +9,10 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { QuizStructureTest } from "@/components/quiz/QuizStructureTest";
 import { ForceRecoveryButton } from "@/components/admin/ForceRecoveryButton";
-import { Loader2, AlertCircle, CheckCircle, Database, Server } from "lucide-react";
+import { Loader2, AlertCircle, CheckCircle, Database, Server, Webhook } from "lucide-react";
 import { testSupabaseStructure } from "@/utils/testSupabaseStructure";
 import { forceQuizRecovery } from "@/scripts/force-quiz-recovery";
+import WebhookTester from '@/components/debug/WebhookTester';
 
 const DiagnosticoSistema: React.FC = () => {
   const { isAdmin } = useAuth();
@@ -74,6 +75,10 @@ const DiagnosticoSistema: React.FC = () => {
             <TabsTrigger value="questionario" className="flex items-center gap-2">
               <Server className="h-4 w-4" />
               Questionário
+            </TabsTrigger>
+            <TabsTrigger value="webhook" className="flex items-center gap-2">
+              <Webhook className="h-4 w-4" />
+              Webhook
             </TabsTrigger>
           </TabsList>
           
@@ -209,6 +214,10 @@ const DiagnosticoSistema: React.FC = () => {
                 )}
               </CardFooter>
             </Card>
+          </TabsContent>
+
+          <TabsContent value="webhook">
+            <WebhookTester />
           </TabsContent>
         </Tabs>
       </div>

--- a/src/utils/supabaseUtils.ts
+++ b/src/utils/supabaseUtils.ts
@@ -1,4 +1,5 @@
-import { supabase, supabaseAdmin } from '@/integrations/supabase/client';
+import { supabase } from '@/integrations/supabase/client';
+import { getSupabaseAdminClient } from '@/utils/supabaseAdminClient';
 import { logger } from '@/utils/logger';
 import { QuizAnswer, QuizQuestion } from '@/types/quiz';
 
@@ -58,6 +59,7 @@ export async function completeQuizManually(userId: string) {
     }
     
     // Método alternativo: atualização direta via admin
+    const supabaseAdmin = getSupabaseAdminClient();
     const { data: submission, error: fetchError } = await supabaseAdmin
       .from('quiz_submissions')
       .select('id')
@@ -69,7 +71,7 @@ export async function completeQuizManually(userId: string) {
     }
     
     if (submission) {
-      const { error: updateError } = await supabaseAdmin
+      const { error: updateError } = await getSupabaseAdminClient()
         .from('quiz_submissions')
         .update({
           completed: true,
@@ -89,11 +91,11 @@ export async function completeQuizManually(userId: string) {
       return { success: true, method: 'direct_update' };
     } else {
       // Buscar email do usuário antes de criar submissão
-      const { data: userData, error: userError } = await supabaseAdmin.auth.admin.getUserById(userId);
+      const { data: userData, error: userError } = await getSupabaseAdminClient().auth.admin.getUserById(userId);
       const userEmail = userData?.user?.email || '';
       
       // Caso não encontre submissão, cria uma já completa
-      const { data: newSubmission, error: createError } = await supabaseAdmin
+      const { data: newSubmission, error: createError } = await getSupabaseAdminClient()
         .from('quiz_submissions')
         .insert([{
           user_id: userId,
@@ -310,6 +312,7 @@ export function processQuizAnswersToSimplified(questions, answers) {
  */
 export async function getQuizCompletedAnswers(submissionId: string) {
   try {
+    const supabaseAdmin = getSupabaseAdminClient();
     // Buscar detalhes da submissão
     const { data: submission, error: submissionError } = await supabaseAdmin
       .from('quiz_submissions')

--- a/src/utils/webhookUtils.ts
+++ b/src/utils/webhookUtils.ts
@@ -108,7 +108,7 @@ export async function sendQuizDataToWebhook(
           )
         `)
         .eq('submission_id', submissionId)
-        .order('quiz_questions.order_number');
+        .order('order_number', { foreignTable: 'quiz_questions' });
 
       if (answersError || !answers || answers.length === 0) {
         const message = 'Nenhuma resposta encontrada para esta submissão';


### PR DESCRIPTION
Esta alteração corrige um erro crítico que impedia o webhook de funcionar corretamente. A query para buscar as respostas do quiz usava uma sintaxe de ordenação inválida para tabelas relacionadas no PostgREST.

- A query em `webhookUtils.ts` foi atualizada para usar a sintaxe correta `.order('order_number', { foreignTable: 'quiz_questions' })`.
- O uso do cliente admin do Supabase foi padronizado em `supabaseUtils.ts` para usar consistentemente a função `getSupabaseAdminClient()`, garantindo que a chave de `service_role` correta seja sempre utilizada.

feat: Adiciona ferramenta de teste de webhook na página de diagnóstico

Para facilitar a validação e futuros diagnósticos, uma nova aba "Webhook" foi adicionada à página `DiagnosticoSistema`. Esta aba renderiza o componente `WebhookTester`, que permite testar a conexão com o webhook diretamente da interface da aplicação.