### PR TITLE
feat: Reestrutura o payload do webhook para ser aninhado e ordenado

### DIFF
--- a/src/components/debug/WebhookTester.tsx
+++ b/src/components/debug/WebhookTester.tsx
@@ -1,4 +1,3 @@
-
 import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';


### PR DESCRIPTION
Esta alteração refatora a montagem do payload do webhook para resolver problemas de ordenação e facilitar o processamento no Make.com.

- A query em `webhookUtils.ts` foi modificada para buscar os módulos relacionados e ordenar os resultados primeiro pela ordem do módulo e depois pela ordem da pergunta.
- A lógica de formatação foi reescrita para criar uma estrutura de payload aninhada, agrupando as perguntas e respostas dentro de seus respectivos módulos.
- O payload agora inclui um array `Modulos`, onde cada objeto de módulo contém seu nome, ordem e uma lista de respostas ordenadas.
- Adiciona o componente `WebhookTester` e o integra à página de diagnóstico para permitir testes de conectividade do webhook.