### PR TITLE
Refatora e corrige os problemas do questionário de rádio

### DIFF
--- a/src/components/quiz/question-types/RadioWithOther.tsx
+++ b/src/components/quiz/question-types/RadioWithOther.tsx
@@ -23,25 +23,25 @@ export const RadioWithOther: React.FC<RadioWithOtherProps> = ({
   hint,
   error
 }) => {
-  const [otherText, setOtherText] = useState('');
-  const [selectedValue, setSelectedValue] = useState(value);
-  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+  const [internalOtherText, setInternalOtherText] = useState('');
+  const [selectedValue, setSelectedValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  // Encontrar a opção "Outro" ou "Outros"
   const otherOption = options.find(option => 
     option.text.toLowerCase().includes('outro')
   );
 
-  // Verificar se o valor atual é um texto personalizado (não está nas opções predefinidas)
   const isCustomValue = value && !options.some(option => option.text === value);
 
   useEffect(() => {
     if (isCustomValue && otherOption) {
       setSelectedValue(otherOption.text);
-      setOtherText(value);
+      setInternalOtherText(value);
     } else {
       setSelectedValue(value);
-      setOtherText('');
+      if (value !== otherOption?.text) {
+        setInternalOtherText('');
+      }
     }
   }, [value, isCustomValue, otherOption]);
 
@@ -49,42 +49,31 @@ export const RadioWithOther: React.FC<RadioWithOtherProps> = ({
     setSelectedValue(selectedOptionText);
     
     if (otherOption && selectedOptionText === otherOption.text) {
-      // Se selecionou "Outro", manter o texto atual ou limpar
-      onChange(otherText || selectedOptionText);
+      if (internalOtherText) {
+        onChange(internalOtherText);
+      } else {
+        onChange(selectedOptionText);
+      }
+      inputRef.current?.focus();
     } else {
-      // Se selecionou uma opção predefinida, usar o texto da opção
-      setOtherText('');
+      setInternalOtherText('');
       onChange(selectedOptionText);
     }
   };
 
-  const handleOtherTextChange = (text: string) => {
-    setOtherText(text);
-    
-    // Clear previous timeout
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current);
+  const handleOtherTextBlur = () => {
+    if (otherOption) {
+      onChange(internalOtherText.trim() ? internalOtherText : otherOption.text);
     }
-    
-    // Debounce the onChange call
-    debounceRef.current = setTimeout(() => {
-      if (otherOption && selectedValue === otherOption.text) {
-        // Sempre enviar o texto digitado, mesmo se estiver vazio
-        onChange(text.trim() ? text : otherOption.text);
-      }
-    }, 500);
   };
 
   const isOtherSelected = otherOption && selectedValue === otherOption.text;
 
-  // Cleanup timeout on unmount
   useEffect(() => {
-    return () => {
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-      }
-    };
-  }, []);
+    if (isOtherSelected) {
+      inputRef.current?.focus();
+    }
+  }, [isOtherSelected]);
 
   return (
     <div className="grid gap-2">
@@ -106,13 +95,14 @@ export const RadioWithOther: React.FC<RadioWithOtherProps> = ({
               </Label>
             </div>
             
-            {/* Campo de texto adicional para "Outro" */}
             {otherOption && option.id === otherOption.id && isOtherSelected && (
               <div className="ml-6">
                 <Input
+                  ref={inputRef}
                   type="text"
-                  value={otherText}
-                  onChange={(e) => handleOtherTextChange(e.target.value)}
+                  value={internalOtherText}
+                  onChange={(e) => setInternalOtherText(e.target.value)}
+                  onBlur={handleOtherTextBlur}
                   placeholder="Especifique..."
                   disabled={disabled}
                   className="w-full"


### PR DESCRIPTION
Esta alteração aborda dois problemas críticos no componente do questionário:

1.  As respostas das perguntas do tipo rádio não estavam sendo salvas corretamente devido a uma inconsistência entre o `id` da opção e o `text` da opção usado como valor.
2.  O campo de entrada de texto para a opção 'Outro' perdia o foco rapidamente, prejudicando a experiência do usuário.

Para resolver isso, a lógica para as perguntas de rádio foi refatorada para um componente especializado `RadioWithOther.tsx`.

Principais alterações:
- `QuestionCard.tsx` foi simplificado para delegar a renderização e o gerenciamento de estado das perguntas de rádio para `RadioWithOther.tsx`.
- `RadioWithOther.tsx` agora gerencia o estado do campo 'Outro' internamente, atualizando o valor no `onBlur` para evitar re-renderizações desnecessárias e perda de foco.
- O foco é definido automaticamente para o campo de texto 'Outro' quando selecionado.
- O código em `QuestionCard.tsx` foi otimizado removendo estados e lógicas redundantes.